### PR TITLE
Added Node selector

### DIFF
--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -16,7 +16,8 @@
 
   1. Set-up and customization
 
-      - Quick set-up<br>
+      - Quick set-up
+
         This is the fastest way to deploy Plane with default settings. This will create stateful deployments for Postgres, Rabbitmq, Redis, and Minio with a persistent volume claim using the default storage class. This also sets up the ingress routes for you using `nginx` ingress class.
         > To customize this, see `Custom ingress routes` below.
 
@@ -36,7 +37,7 @@
               --wait-for-jobs
           ```
 
-        > This is the basic setup required for Plane-CE. You can customize the default values for namespace and appname as needed. Additional settings can be configured by referring to the Configuration Settings section.<br>
+        > This is the basic setup required for Plane-CE. You can customize the default values for namespace and appname as needed. Additional settings can be configured by referring to the Configuration Settings section.
 
         Using a Custom StorageClass
 
@@ -297,7 +298,6 @@
 | env.secret_key | 60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5 | Yes | This must a random string which is used for hashing/encrypting the sensitive data within the application. Once set, changing this might impact the already hashed/encrypted data|
 | env.default_cluster_domain | cluster.local | Yes | Set this value as configured in your kubernetes cluster. `cluster.local` is usally the default in most cases. |
 
-
 ## External Secrets Config
 
 To configure the external secrets for your application, you need to define specific environment variables for each secret category. Below is a list of the required secrets and their respective environment variables.
@@ -323,7 +323,6 @@ To configure the external secrets for your application, you need to define speci
 |                      | `DATABASE_URL`           | Yes | PostgreSQL connection URL                    | **k8s service example**: `postgresql://plane:plane@plane-pgdb.plane-ns.svc.cluster.local:5432/plane` <br> <br>**external service example**: `postgresql://username:password@your-db-host:5432/plane` |
 |                      | `AMQP_URL`               | Yes | RabbitMQ connection URL                      | **k8s service example**: `amqp://plane:plane@plane-rabbitmq.plane-ns.svc.cluster.local:5672/`  <br> <br> **external service example**: `amqp://username:password@your-rabbitmq-host:5672/` |
 | live_env_existingSecret      | `REDIS_URL`              | Yes | Redis URL                                    | `redis://plane-redis.plane-ns.svc.cluster.local:6379/` |
-
 
 ## Custom Ingress Routes
 

--- a/charts/plane-ce/README.md
+++ b/charts/plane-ce/README.md
@@ -1,3 +1,5 @@
+# Plane-CE Helm Chart
+
 ## Pre-requisite
 
 - A working Kubernetes cluster
@@ -39,14 +41,17 @@
         Using a Custom StorageClass
 
         To specify a custom StorageClass for Plane-CE components, add the following options to the above `helm upgrade --install` command:
+
         ```bash
         --set postgres.storageClass=<your-storageclass-name>
         --set redis.storageClass=<your-storageclass-name>
         --set minio.storageClass=<your-storageclass-name>
         --set rabbitmq.storageClass=<your-storageclass-name>
         ```
-      - Advance set-up<br>
-        For more control over your set-up, run the script below to download the `values.yaml` file and and edit using any editor like Vim or Nano. 
+
+      - Advance set-up
+
+        For more control over your set-up, run the script below to download the `values.yaml` file and and edit using any editor like Vim or Nano.
 
         ```bash
         helm  show values makeplane/plane-ce > values.yaml
@@ -90,6 +95,9 @@
 | env.pgdb_remote_url |  |  | Users can also decide to use the remote hosted database and link to Plane deployment. Ignoring all the above keys, set `postgres.local_setup` to `false` and set this key with remote connection url. |
 | postgres.storageClass | &lt;k8s-default-storage-class&gt; |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
 | postgres.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+| postgres.nodeSelector | {} |  | This key allows you to set the node selector for the stateful deployment of `postgres`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| postgres.tolerations | [] |  | This key allows you to set the tolerations for the stateful deployment of `postgres`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| postgres.affinity | {} |  | This key allows you to set the affinity rules for the stateful deployment of `postgres`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Redis/Valkey Setup
 
@@ -103,7 +111,9 @@
 | env.remote_redis_url |  |  | Users can also decide to use the remote hosted database and link to Plane deployment. Ignoring all the above keys, set `redis.local_setup` to `false` and set this key with remote connection url. |
 | redis.storageClass | &lt;k8s-default-storage-class&gt; |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
 | redis.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
-
+| redis.nodeSelector | {} |  | This key allows you to set the node selector for the stateful deployment of `redis`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| redis.tolerations | [] |  | This key allows you to set the tolerations for the stateful deployment of `redis`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| redis.affinity | {} |  | This key allows you to set the affinity rules for the stateful deployment of `redis`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### RabbitMQ Setup
 
@@ -120,6 +130,9 @@
 | rabbitmq.default_password | plane |  | Credentials are requried to access the hosted stateful deployment of `rabbitmq`.  Use this key to set the password for the stateful deployment. |
 | rabbitmq.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
 | rabbitmq.external_rabbitmq_url |  |  | Users can also decide to use the remote hosted service and link to Plane deployment. Ignoring all the above keys, set `rabbitmq.local_setup` to `false` and set this key with remote connection url. |
+| rabbitmq.nodeSelector | {} |  | This key allows you to set the node selector for the stateful deployment of `rabbitmq`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| rabbitmq.tolerations | [] |  | This key allows you to set the tolerations for the stateful deployment of `rabbitmq`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| rabbitmq.affinity | {} |  | This key allows you to set the affinity rules for the stateful deployment of `rabbitmq`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Doc Store (Minio/S3) Setup
 
@@ -141,6 +154,9 @@
 | env.aws_s3_endpoint_url |  |  | External `S3` (or compatible) storage service providers shares a `endpoint_url` for the integration purpose for the application to connect and do the necessary upload/download operations. To be provided when `minio.local_setup=false`  |
 | minio.storageClass | &lt;k8s-default-storage-class&gt; |  | Creating the persitant volumes for the stateful deployments needs the `storageClass` name. Set the correct value as per your kubernetes cluster configuration. |
 | minio.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+| minio.nodeSelector | {} |  | This key allows you to set the node selector for the stateful deployment of `minio`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| minio.tolerations | [] |  | This key allows you to set the tolerations for the stateful deployment of `minio`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| minio.affinity | {} |  | This key allows you to set the affinity rules for the stateful deployment of `minio`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Web Deployment
 
@@ -154,6 +170,9 @@
 | web.image| artifacts.plane.so/makeplane/plane-frontend |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | web.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `web`. |  
 | web.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+| web.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of `web`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| web.tolerations | [] |  | This key allows you to set the tolerations for the deployment of `web`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| web.affinity | {} |  | This key allows you to set the affinity rules for the deployment of `web`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Space Deployment
 
@@ -167,6 +186,9 @@
 | space.image| artifacts.plane.so/makeplane/plane-space|  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | space.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `space`. |
 | space.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+| space.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of `space`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| space.tolerations | [] |  | This key allows you to set the tolerations for the deployment of `space`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| space.affinity | {} |  | This key allows you to set the affinity rules for the deployment of `space`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Admin Deployment
 
@@ -180,6 +202,9 @@
 | admin.image| artifacts.plane.so/makeplane/plane-admin |  |  This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
 | admin.pullPolicy | Always |  | Using this key, user can set the pull policy for the deployment of `admin`. |
 | admin.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+| admin.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of `admin`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| admin.tolerations | [] |  | This key allows you to set the tolerations for the deployment of `admin`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| admin.affinity | {} |  | This key allows you to set the affinity rules for the deployment of `admin`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Live Service Deployment
 
@@ -196,6 +221,9 @@
 | env.live_sentry_environment |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
 | env.live_sentry_traces_sample_rate |  |  | (optional) Live service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry trace sample rate (as configured in Sentry) for this integration.|
 | live.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+| live.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of `live`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| live.tolerations | [] |  | This key allows you to set the tolerations for the deployment of `live`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| live.affinity | {} |  | This key allows you to set the affinity rules for the deployment of `live`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### API Deployment
 
@@ -212,6 +240,9 @@
 | env.sentry_environment |  |  | (optional) API service deployment comes with some of the preconfigured integration. Sentry is one among those. Here user can set the Sentry environment name (as configured in Sentry) for this integration.|
 | env.api_key_rate_limit | 60/minute |  | (optional) User can set the maximum number of requests the API can handle in a given time frame.|
 | api.assign_cluster_ip | false |  | Set it to `true` if you want to assign `ClusterIP` to the service |
+| api.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of `api`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| api.tolerations | [] |  | This key allows you to set the tolerations for the deployment of `api`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| api.affinity | {} |  | This key allows you to set the affinity rules for the deployment of `api`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Worker Deployment
 
@@ -223,6 +254,9 @@
 | worker.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
 | worker.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | worker.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| worker.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of `worker`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| worker.tolerations | [] |  | This key allows you to set the tolerations for the deployment of `worker`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| worker.affinity | {} |  | This key allows you to set the affinity rules for the deployment of `worker`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Beat-Worker deployment
 
@@ -234,6 +268,9 @@
 | beatworker.memoryRequest | 50Mi |  | Every deployment in kubernetes can be set to use minimum memory they are allowed to use. This key sets the memory request for this deployment to use.|
 | beatworker.cpuRequest | 50m |  | Every deployment in kubernetes can be set to use minimum cpu they are allowed to use. This key sets the cpu request for this deployment to use.|
 | beatworker.image| artifacts.plane.so/makeplane/plane-backend |  | This deployment needs a preconfigured docker image to function. Docker image name is provided by the owner and must not be changed for this deployment |
+| beatworker.nodeSelector | {} |  | This key allows you to set the node selector for the deployment of `beatworker`. This is useful when you want to run the deployment on specific nodes in your Kubernetes cluster. |
+| beatworker.tolerations | [] |  | This key allows you to set the tolerations for the deployment of `beatworker`. This is useful when you want to run the deployment on nodes with specific taints in your Kubernetes cluster. |
+| beatworker.affinity | {} |  | This key allows you to set the affinity rules for the deployment of `beatworker`. This is useful when you want to control how pods are scheduled on nodes in your Kubernetes cluster. |
 
 ### Ingress and SSL Setup
 

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -58,5 +58,13 @@ spec:
           - admin
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-
+      {{- with .Values.admin.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.admin.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admin.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -58,13 +58,13 @@ spec:
           - admin
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.admin.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- with .Values.admin.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8}}
       {{- end -}}
-      {{- with .Values.admin.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.admin.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.admin.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.admin.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -75,5 +75,13 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-
+      {{- with .Values.api.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.api.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end -}}
+      {{- with .Values.api.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end -}}
 ---

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -75,13 +75,13 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.api.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8}}
       {{- end -}}
-      {{- with .Values.api.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.api.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
       {{- end -}}
-      {{- with .Values.api.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.api.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end -}}
 ---

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -45,13 +45,13 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.beatworker.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- with .Values.beatworker.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8}}
       {{- end -}}
-      {{- with .Values.beatworker.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.beatworker.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.beatworker.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.beatworker.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -45,5 +45,13 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-
+      {{- with .Values.beatworker.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.beatworker.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.beatworker.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -64,5 +64,13 @@ spec:
               optional: false
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-
+      {{- with .Values.live.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.live.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end -}}
+      {{- with .Values.live.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end -}}
 ---

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -64,13 +64,13 @@ spec:
               optional: false
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.live.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- with .Values.live.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8}}
       {{- end -}}
-      {{- with .Values.live.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.live.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
       {{- end -}}
-      {{- with .Values.live.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.live.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end -}}
 ---

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -60,14 +60,14 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.minio.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- with .Values.minio.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8}}
       {{- end -}}
-      {{- with .Values.minio.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.minio.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.minio.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.minio.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
   - apiVersion: v1

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -60,6 +60,15 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
+      {{- with .Values.minio.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.minio.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/charts/plane-ce/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/postgres.stateful.yaml
@@ -53,14 +53,14 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.postgres.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- with .Values.postgres.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8}}
       {{- end -}}
-      {{- with .Values.postgres.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.postgres.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.postgres.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.postgres.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
   - apiVersion: v1

--- a/charts/plane-ce/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/postgres.stateful.yaml
@@ -53,6 +53,15 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
+      {{- with .Values.postgres.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.postgres.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
@@ -54,14 +54,14 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.rabbitmq.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.rabbitmq.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.rabbitmq.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.rabbitmq.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.rabbitmq.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rabbitmq.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
   - apiVersion: v1

--- a/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
@@ -54,6 +54,15 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
+      {{- with .Values.rabbitmq.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.rabbitmq.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rabbitmq.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/charts/plane-ce/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/redis.stateful.yaml
@@ -49,14 +49,14 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.redis.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.redis.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.redis.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.redis.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
   - apiVersion: v1

--- a/charts/plane-ce/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/redis.stateful.yaml
@@ -49,6 +49,15 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
+      {{- with .Values.redis.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.redis.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -58,13 +58,13 @@ spec:
           - space
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.space.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.space.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.space.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8}}
       {{- end }}
-      {{- with .Values.space.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.space.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.space.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -58,5 +58,13 @@ spec:
           - space
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-
+      {{- with .Values.space.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.space.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.space.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -58,5 +58,13 @@ spec:
           - web
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -58,13 +58,13 @@ spec:
           - web
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.web.nodeSelector -}}
+      {{- with .Values.web.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.web.tolerations -}}
+      {{- with .Values.web.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.web.affinity -}}
+      {{- with .Values.web.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -58,13 +58,13 @@ spec:
           - web
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.web.nodeSelector }}
+      {{- with .Values.web.nodeSelector -}}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.web.tolerations }}
+      {{- with .Values.web.tolerations -}}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.web.affinity }}
+      {{- with .Values.web.affinity -}}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -44,5 +44,13 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-
+      {{- with .Values.worker.nodeSelector -}}
+        nodeSelector: {{ toYaml . | nindent 8}}
+      {{- end -}}
+      {{- with .Values.worker.tolerations -}}
+        tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity -}}
+        affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
 ---

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -44,13 +44,13 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.worker.nodeSelector -}}
-        nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.worker.tolerations -}}
-        tolerations: {{ toYaml . | nindent 8 }}
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.worker.affinity -}}
-        affinity: {{ toYaml . | nindent 8 }}
+      {{- with .Values.worker.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
 ---

--- a/charts/plane-ce/values.yaml
+++ b/charts/plane-ce/values.yaml
@@ -33,6 +33,9 @@ redis:
   volumeSize: 100Mi
   pullPolicy: IfNotPresent
   assign_cluster_ip: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 postgres:
   local_setup: true
@@ -42,6 +45,9 @@ postgres:
   volumeSize: 1Gi
   pullPolicy: IfNotPresent
   assign_cluster_ip: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 rabbitmq:
   local_setup: true
@@ -55,6 +61,9 @@ rabbitmq:
   default_password: plane
   external_rabbitmq_url: ''
   assign_cluster_ip: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 minio:
   image: minio/minio:latest
@@ -68,6 +77,9 @@ minio:
   assign_cluster_ip: false
   env:
    minio_endpoint_ssl: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 web:
   replicas: 1
@@ -78,6 +90,9 @@ web:
   image: artifacts.plane.so/makeplane/plane-frontend
   pullPolicy: Always
   assign_cluster_ip: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 space:
   replicas: 1
@@ -88,6 +103,9 @@ space:
   image: artifacts.plane.so/makeplane/plane-space
   pullPolicy: Always
   assign_cluster_ip: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 admin:
   replicas: 1
@@ -98,6 +116,9 @@ admin:
   image: artifacts.plane.so/makeplane/plane-admin
   pullPolicy: Always
   assign_cluster_ip: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 live:
   replicas: 1
@@ -108,6 +129,9 @@ live:
   image: artifacts.plane.so/makeplane/plane-live
   pullPolicy: Always
   assign_cluster_ip: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 api:
   replicas: 1
@@ -118,6 +142,9 @@ api:
   image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
   assign_cluster_ip: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 worker:
   replicas: 1
@@ -127,6 +154,9 @@ worker:
   memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 beatworker:
   replicas: 1
@@ -136,6 +166,9 @@ beatworker:
   memoryRequest: 50Mi
   image: artifacts.plane.so/makeplane/plane-backend
   pullPolicy: Always
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 external_secrets:
   # Name of the existing Kubernetes Secret resource; see README for more details


### PR DESCRIPTION
This pull request introduces enhancements to the `Plane-CE Helm Chart` documentation and templates, focusing on improving Kubernetes deployment configurations. The changes include adding support for `nodeSelector`, `tolerations`, and `affinity` settings across multiple components, enabling more granular control over pod scheduling and placement. Additionally, minor formatting improvements were made to the README file for better readability.

### Documentation Updates:
* Added descriptions for `nodeSelector`, `tolerations`, and `affinity` settings for components such as `postgres`, `redis`, `rabbitmq`, `minio`, `web`, `space`, `admin`, `live`, `api`, `worker`, and `beatworker` in `charts/plane-ce/README.md`. These settings allow users to control pod scheduling based on node attributes, taints, and affinity rules. 

### Template Updates:
* Added `nodeSelector`, `tolerations`, and `affinity` support to the Kubernetes deployment templates for components such as `admin`, `api`, `beatworker`, `live`, and `minio`. This ensures that these configurations can be applied directly via Helm values.

### Formatting Improvements:
* Removed unnecessary `<br>` tags from `charts/plane-ce/README.md` for better markdown formatting. 
* Improved section organization and readability in `charts/plane-ce/README.md`. 