### PR TITLE
Refactor: Pod scheduling configurations

### DIFF
--- a/charts/plane-ce/templates/_helpers.tpl
+++ b/charts/plane-ce/templates/_helpers.tpl
@@ -1,3 +1,14 @@
 {{- define "imagePullSecret" }}
 {{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\"}}}" .Values.dockerRegistry.host .Values.dockerRegistry.loginid .Values.dockerRegistry.password | b64enc }}
 {{- end }}
+{{- define "plane.podScheduling" -}}
+  {{- with .nodeSelector }} 
+      nodeSelector: {{ toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/charts/plane-ce/templates/workloads/admin.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/admin.deployment.yaml
@@ -58,13 +58,5 @@ spec:
           - admin
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.admin.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.admin.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.admin.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.api }}
 ---

--- a/charts/plane-ce/templates/workloads/api.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/api.deployment.yaml
@@ -75,13 +75,5 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.api.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.api.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end -}}
-      {{- with .Values.api.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end -}}
+      {{- template "plane.podScheduling" .Values.api }}
 ---

--- a/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/beat-worker.deployment.yaml
@@ -45,13 +45,5 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.beatworker.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.beatworker.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.beatworker.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.beatworker }}
 ---

--- a/charts/plane-ce/templates/workloads/live.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/live.deployment.yaml
@@ -64,13 +64,5 @@ spec:
               optional: false
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.live.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.live.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end -}}
-      {{- with .Values.live.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end -}}
+      {{- template "plane.podScheduling" .Values.live }}
 ---

--- a/charts/plane-ce/templates/workloads/minio.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/minio.stateful.yaml
@@ -60,15 +60,7 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.minio.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.minio.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.minio.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.minio }}
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/charts/plane-ce/templates/workloads/postgres.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/postgres.stateful.yaml
@@ -53,15 +53,7 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.postgres.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end -}}
-      {{- with .Values.postgres.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.postgres.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.postgres }}
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/rabbitmq.stateful.yaml
@@ -54,15 +54,7 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.rabbitmq.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.rabbitmq.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.rabbitmq.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.rabbitmq }}
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/charts/plane-ce/templates/workloads/redis.stateful.yaml
+++ b/charts/plane-ce/templates/workloads/redis.stateful.yaml
@@ -49,15 +49,7 @@ spec:
           subPath: ''
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.redis.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.redis.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.redis.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.redis }}
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/charts/plane-ce/templates/workloads/space.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/space.deployment.yaml
@@ -58,13 +58,5 @@ spec:
           - space
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.space.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8}}
-      {{- end }}
-      {{- with .Values.space.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.space.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.space }}
 ---

--- a/charts/plane-ce/templates/workloads/web.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/web.deployment.yaml
@@ -58,13 +58,5 @@ spec:
           - web
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.web.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.web.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.web.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.web }}
 ---

--- a/charts/plane-ce/templates/workloads/worker.deployment.yaml
+++ b/charts/plane-ce/templates/workloads/worker.deployment.yaml
@@ -44,13 +44,5 @@ spec:
 
       serviceAccount: {{ .Release.Name }}-srv-account
       serviceAccountName: {{ .Release.Name }}-srv-account
-      {{- with .Values.worker.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.worker.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.worker.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{- template "plane.podScheduling" .Values.worker }}
 ---


### PR DESCRIPTION
This pull request refactors the Helm chart templates for the `plane-ce` project to improve maintainability and reduce duplication. It introduces a reusable helper function for pod scheduling configurations (`nodeSelector`, `tolerations`, and `affinity`) and replaces the inline scheduling logic in multiple workload templates with this new helper.

### Refactoring for pod scheduling:

* **Helper function creation**: Added a new helper function `plane.podScheduling` in `charts/plane-ce/templates/_helpers.tpl` to encapsulate pod scheduling configurations (`nodeSelector`, `tolerations`, and `affinity`). This reduces redundancy across workload templates.

* **Workload template updates**:
  - Replaced inline pod scheduling logic with the `plane.podScheduling` helper in the following files:
    - `admin.deployment.yaml`
    - `api.deployment.yaml`
    - `beat-worker.deployment.yaml`
    - `live.deployment.yaml`
    - `minio.stateful.yaml`
    - `postgres.stateful.yaml`
    - `rabbitmq.stateful.yaml`
    - `redis.stateful.yaml`
    - `space.deployment.yaml`
    - `web.deployment.yaml`
    - `worker.deployment.yaml`